### PR TITLE
Set up GitHub Actions for C

### DIFF
--- a/github-ci-workflow.yml
+++ b/github-ci-workflow.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        ghc: ['9.4.7', '9.6.3', '9.8.1', '9.10.1']
+        cabal: ['3.10']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Haskell
+      uses: haskell-actions/setup@v2
+      id: setup
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Configure
+      run: |
+        cabal configure --enable-tests --enable-benchmarks --disable-documentation
+        cabal build all --dry-run
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-plan-${{ hashFiles('**/plan.json') }}
+        restore-keys: |
+          ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-
+
+    - name: Install dependencies
+      run: cabal build all --only-dependencies
+
+    - name: Save cached dependencies
+      uses: actions/cache/save@v4
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Build
+      run: cabal build all
+
+    - name: Run tests
+      run: cabal test all
+
+    - name: Generate documentation
+      if: matrix.ghc == '9.10.1'
+      run: cabal haddock all
+
+  stack-build:
+    name: Stack build and test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Haskell Stack
+      uses: haskell-actions/setup@v2
+      with:
+        enable-stack: true
+        stack-version: 'latest'
+
+    - name: Cache Stack dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml', 'fastly.cabal') }}
+        restore-keys: |
+          ${{ runner.os }}-stack-
+
+    - name: Build with Stack
+      run: stack build --test --no-run-tests
+
+    - name: Run tests with Stack
+      run: stack test
+
+    - name: Generate documentation with Stack
+      run: stack haddock


### PR DESCRIPTION
Add comprehensive CI workflow file for GitHub Actions:
- Test across multiple GHC versions (9.4.7, 9.6.3, 9.8.1, 9.10.1)
- Both Cabal and Stack build configurations
- Run test suite
- Generate Haddock documentation
- Cache dependencies for faster builds

Note: Move this file to .github/workflows/ci.yml to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)